### PR TITLE
Clone repository as provided user/group.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'apache2'
 description      'Installs/Configures nodejs-webapp'
 long_description 'Installs/Configures nodejs-webapp'
 version          '1.0.0'
+issues_url       'https://github.com/osuosl-cookbooks/nodejs-webapp/issues'
+source_url       'https://github.com/osuosl-cookbooks/nodejs-webapp'
 
 depends 'build-essential'
 depends 'git'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,6 @@ depends 'git'
 depends 'magic_shell'
 depends 'nodejs'
 depends 'pm2'
+
+supports         'centos', '~> 6.0'
+supports         'centos', '~> 7.0'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# Separate resource into own context
+use_inline_resources
+
 action :install do
   run_context.include_recipe 'git'
   run_context.include_recipe 'build-essential'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,7 +73,8 @@ action :install do
     end
   end
 
-  pm2_home = "/home/#{new_resource.user}"
+  # If we're working as root, we need to use /root instead of /home/root
+  pm2_home = new_resource.user == "root" ? "/root" : "/home/#{new_resource.user}"
 
   # evaluate the resource name at evaluation time to avoid context problem
   pm2_application new_resource.name do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -74,7 +74,8 @@ action :install do
   end
 
   # If we're working as root, we need to use /root instead of /home/root
-  pm2_home = new_resource.user == "root" ? "/root" : "/home/#{new_resource.user}"
+  pm2_home = "/home/#{new_resource.user}"
+  pm2_home = '/root' if new_resource.user == 'root'
 
   # evaluate the resource name at evaluation time to avoid context problem
   pm2_application new_resource.name do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -76,7 +76,7 @@ action :install do
   pm2_home = "/home/#{new_resource.user}"
 
   # evaluate the resource name at evaluation time to avoid context problem
-  pm2_application "#{new_resource.name}" do
+  pm2_application new_resource.name do
     user new_resource.user
     script new_resource.script
     cwd "#{path}/source"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -56,6 +56,8 @@ action :install do
     repository new_resource.repository
     revision new_resource.branch
     destination "#{path}/source"
+    user new_resource.user
+    group new_resource.group
   end
 
   if new_resource.install_deps # ~FC023

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -31,9 +31,9 @@ describe 'nodejs-webapp-test::default' do
   it 'checks out test_a and test_b' do
     expect(chef_run).to sync_git('/opt/custom').with(
       repository: 'https://github.com/osuosl/nodejs-test-apps.git',
-      branch: 'custom'
+      branch: 'custom',
       user: 'test_a',
-      group: 'test_a',
+      group: 'test_a'
     )
     expect(chef_run).to sync_git('/opt/test_b').with(
       repository: 'https://github.com/osuosl/nodejs-test-apps.git'

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 describe 'nodejs-webapp-test::default' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      step_into: ['nodejs-webapp']).converge(described_recipe)
+      step_into: ['nodejs-webapp']
+    ).converge(described_recipe)
   end
 
   it 'installs nodejs webapp for test_a and test_b' do
@@ -30,30 +31,36 @@ describe 'nodejs-webapp-test::default' do
   it 'checks out test_a and test_b' do
     expect(chef_run).to sync_git('/opt/custom').with(
       repository: 'https://github.com/osuosl/nodejs-test-apps.git',
-      branch: 'custom')
+      branch: 'custom'
+    )
     expect(chef_run).to sync_git('/opt/test_b').with(
-      repository: 'https://github.com/osuosl/nodejs-test-apps.git')
+      repository: 'https://github.com/osuosl/nodejs-test-apps.git'
+    )
   end
 
   it 'installs dependencies for test_a with npm' do
     expect(chef_run).to run_bash('test_a: npm install').with(
-      cwd: '/opt/custom/source')
+      cwd: '/opt/custom/source'
+    )
   end
 
   it 'installs the latest version of npm' do
     expect(chef_run).to run_bash('upgrade npm').with(
-      code: 'npm -g install npm')
+      code: 'npm -g install npm'
+    )
   end
 
   it 'should not install dependencies for test_b with npm' do
     expect(chef_run).not_to run_bash('test_b: npm install').with(
-      cwd: '/opt/test_b')
+      cwd: '/opt/test_b'
+    )
   end
 
   it 'should start or restart app script run.js with pm2' do
     expect(chef_run).to start_or_reload_pm2_application('test_a').with(
       script: 'run.js',
       user: 'test_a',
-      node_args: %w(--harmony --no-deprecation))
+      node_args: %w(--harmony --no-deprecation)
+    )
   end
 end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -32,6 +32,8 @@ describe 'nodejs-webapp-test::default' do
     expect(chef_run).to sync_git('/opt/custom').with(
       repository: 'https://github.com/osuosl/nodejs-test-apps.git',
       branch: 'custom'
+      user: 'test_a',
+      group: 'test_a',
     )
     expect(chef_run).to sync_git('/opt/test_b').with(
       repository: 'https://github.com/osuosl/nodejs-test-apps.git'

--- a/test/cookbooks/nodejs-webapp-test/recipes/default.rb
+++ b/test/cookbooks/nodejs-webapp-test/recipes/default.rb
@@ -50,4 +50,5 @@ nodejs_webapp 'test_b' do
   script 'run.js'
   repository 'https://github.com/osuosl/nodejs-test-apps.git'
   install_deps false
+  branch 'master'
 end

--- a/test/integration/default/serverspec/test_git_spec.rb
+++ b/test/integration/default/serverspec/test_git_spec.rb
@@ -37,7 +37,7 @@ end
 
 # Test that the right revision has been checked out
 describe command('cd /opt/test_b/source/ && '\
-  'git symbolic-ref --short HEAD') do
+  'git symbolic-ref HEAD') do
   its(:stdout) { should match 'master' }
   its(:stderr) { should match '' }
 end

--- a/test/integration/default/serverspec/test_git_spec.rb
+++ b/test/integration/default/serverspec/test_git_spec.rb
@@ -37,7 +37,6 @@ end
 
 # Test that the right revision has been checked out
 describe command('cd /opt/test_b/source/ && '\
-  'git symbolic-ref HEAD') do
-  its(:stdout) { should match 'master' }
-  its(:stderr) { should match '' }
+  'diff <(git rev-parse HEAD) <(git rev-parse origin/master)') do
+  its(:stdout) { should match '' }
 end

--- a/test/integration/default/serverspec/test_git_spec.rb
+++ b/test/integration/default/serverspec/test_git_spec.rb
@@ -11,8 +11,8 @@ end
 # Test that the git repository is actually a git repository
 describe file('/opt/custom/source/.git') do
   it { should be_directory }
-  it { should be_grouped_into 'root' }
-  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'test_a' }
+  it { should be_owned_by 'test_a' }
 end
 
 # Test that the right revision has been checked out
@@ -39,4 +39,5 @@ end
 describe command('cd /opt/test_b/source/ && '\
   'git symbolic-ref --short HEAD') do
   its(:stdout) { should match 'master' }
+  its(:stderr) { should match '' }
 end

--- a/test/integration/default/serverspec/test_pm2_config_spec.rb
+++ b/test/integration/default/serverspec/test_pm2_config_spec.rb
@@ -22,7 +22,7 @@ describe file('/etc/pm2/conf.d/test_b.json') do
   its(:content) { should contain '/opt/test_b/source' }
 end
 
-describe file('/etc/init.d/pm2-startup.sh') do
+describe file('/etc/init.d/pm2-init.sh') do
   it { should be_file }
 end
 


### PR DESCRIPTION
Related to https://github.com/osuosl-cookbooks/timesync/pull/10, the git resource currently clones the repository as the user which calls chef-client (i.e. usually root). This change causes it to check it out as the provided user and group, ensuring proper permissions regardless of caller.

@osuosl-cookbooks/staff 
