### PR TITLE
Provide separate install and run actions for finer control.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,5 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
+Metrics/BlockLength:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache: bundler
 install:
   - bundle install --retry=3
 script:
-  - bundle exec rake travis
+  - bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'chef', '= 12.10.24'
 gem 'berkshelf', '~> 4.3.3'
 gem 'test-kitchen'
 gem 'kitchen-openstack'

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,3 @@
-#
-# Cookbook Name:: nodejs-webapp
-#
-# Copyright Chef, Oregon State University
-#
-# Original authors: https://github.com/chef-cookbooks/yum/blob/master/Rakefile
-#
-# Licensed under the Apache License, Version 2.0 (the 'License');
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Rake tasks
 
 require 'rake'
@@ -27,60 +8,123 @@ require 'chef/encrypted_data_bag_item'
 require 'json'
 require 'openssl'
 
-require 'rspec/core/rake_task'
+snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
+encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
+
+##
+# Run command wrapper
+def run_command(command)
+  if File.exist?('Gemfile.lock')
+    sh %(bundle exec #{command})
+  else
+    sh %(chef exec #{command})
+  end
+end
+
+##
+# Create a self-signed SSL certificate
+#
+def gen_ssl_cert
+  name = OpenSSL::X509::Name.new [
+    ['C', 'US'],
+    ['ST', 'Oregon'],
+    ['CN', 'OSU Open Source Lab'],
+    ['DC', 'example']
+  ]
+  key = OpenSSL::PKey::RSA.new 2048
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 2
+  cert.subject = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+
+  # Self-sign the Certificate
+  cert.issuer = name
+  cert.sign(key, OpenSSL::Digest::SHA1.new)
+
+  return cert, key
+end
+
+##
+# Create a data bag item (with the id of snakeoil) containing a self-signed SSL
+#  certificate
+#
+def ssl_data_bag_item
+  cert, key = gen_ssl_cert
+  Chef::DataBagItem.from_hash(
+    'id' => 'snakeoil',
+    'cert' => cert.to_pem,
+    'key' => key.to_pem
+  )
+end
+
+##
+# Create the integration tests directory if it doesn't exist
+#
+directory 'test/integration'
+
+##
+# Generates a 512 byte random sequence and write it to
+#  'test/integration/encrypted_data_bag_secret'
+#
+file encrypted_data_bag_secret_path => 'test/integration' do
+  encrypted_data_bag_secret = OpenSSL::Random.random_bytes(512)
+  open encrypted_data_bag_secret_path, 'w' do |io|
+    io.write Base64.encode64(encrypted_data_bag_secret)
+  end
+end
+
+##
+# Create the certificates data bag if it doesn't exist
+#
+directory 'test/integration/data_bags/certificates' => 'test/integration'
+
+##
+# Create the encrypted snakeoil certificate under
+#  test/integration/data_bags/certificates
+#
+file snakeoil_file_path => [
+  'test/integration/data_bags/certificates',
+  'test/integration/encrypted_data_bag_secret'
+] do
+
+  encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
+    encrypted_data_bag_secret_path
+  )
+
+  encrypted_snakeoil_cert = Chef::EncryptedDataBagItem.encrypt_data_bag_item(
+    ssl_data_bag_item, encrypted_data_bag_secret
+  )
+
+  open snakeoil_file_path, 'w' do |io|
+    io.write JSON.pretty_generate(encrypted_snakeoil_cert)
+  end
+end
+
+desc 'Create an Encrypted Databag Snakeoil SSL Certificate'
+task snakeoil: snakeoil_file_path
+
+desc 'Create an Encrypted Databag Secret'
+task secret_file: encrypted_data_bag_secret_path
+
 require 'rubocop/rake_task'
-require 'foodcritic'
-require 'kitchen'
+desc 'Run RuboCop (style) tests'
+RuboCop::RakeTask.new(:style)
 
-# Style tests. Rubocop and Foodcritic
-namespace :style do
-  desc 'Run Ruby style checks'
-  RuboCop::RakeTask.new(:ruby)
-
-  desc 'Run Chef style checks'
-  FoodCritic::Rake::LintTask.new(:chef) do |t|
-    t.options = {
-      fail_tags: ['any']
-    }
-  end
+desc 'Run FoodCritic (lint) tests'
+task :lint do
+    run_command('foodcritic --epic-fail any .')
 end
 
-desc 'Run all style checks'
-task style: %w(style:chef style:ruby)
-
-# Rspec and ChefSpec
-desc 'Run ChefSpec tests'
-RSpec::Core::RakeTask.new(:spec)
-
-# Integration tests. Kitchen.ci
-namespace :integration do
-  desc 'Run Test Kitchen with Vagrant'
-  task :vagrant do
-    Kitchen.logger = Kitchen.default_file_logger
-    Kitchen::Config.new.instances.each do |instance|
-      instance.test(:always)
-    end
-  end
-
-  desc 'Run Test Kitchen with cloud plugins'
-  task :cloud do
-    Kitchen.logger = Kitchen.default_file_logger
-    @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.cloud.yml')
-    config = Kitchen::Config.new(loader: @loader)
-    config.instances.each do |instance|
-      instance.test(:always)
-    end
-  end
+desc 'Run RSpec (unit) tests'
+task :unit do
+    run_command('rspec')
 end
 
-desc 'Run all tests (style, spec, integration) on Openstack'
-task cloud: %w(style spec integration:cloud)
+desc 'Run all tests'
+task test: [:style, :lint, :unit]
 
-desc 'Run all tests (style, spec, integration) on Vagrant'
-task vagrant: %w(style spec integration:vagrant)
-
-desc 'Run style and spec tests (for Travis)'
-task travis: %w(style spec)
-
-# Default
-task default: %w(style spec integration:vagrant)
+task default: :test

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -2,4 +2,8 @@ if defined?(ChefSpec)
   def install_nodejs_webapp(name)
     ChefSpec::Matchers::ResourceMatcher.new(:nodejs_webapp, :install, name)
   end
+
+  def run_nodejs_webapp(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nodejs_webapp, :run, name)
+  end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -91,7 +91,31 @@ action :install do
     home pm2_home
     node_args new_resource.node_args
     env new_resource.env
-    action [:deploy, :start]
+    action [:deploy]
+  end
+
+  new_resource.updated_by_last_action(true)
+end
+
+action :run do
+  run_context.include_recipe 'pm2'
+
+  # If the new_resource.path is nil set the install path to
+  # `/opt/name_attribute`
+  path = new_resource.path || "/opt/#{new_resource.name}"
+
+  # If we're working as root, we need to use /root instead of /home/root
+  pm2_home = "/home/#{new_resource.user}"
+  pm2_home = '/root' if new_resource.user == 'root'
+
+  pm2_application new_resource.name do
+    user new_resource.user
+    script new_resource.script
+    cwd "#{path}/source"
+    home pm2_home
+    node_args new_resource.node_args
+    env new_resource.env
+    action [:start]
   end
 
   # because pm2 can only write one startup script at a time, we're limited to

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+actions :install, :run
 default_action :install
 
 # The information necessary to check out the code

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -57,12 +57,4 @@ describe 'nodejs-webapp-test::default' do
       cwd: '/opt/test_b'
     )
   end
-
-  it 'should start or restart app script run.js with pm2' do
-    expect(chef_run).to start_pm2_application('test_a').with(
-      script: 'run.js',
-      user: 'test_a',
-      node_args: %w(--harmony --no-deprecation)
-    )
-  end
 end

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -57,4 +57,17 @@ describe 'nodejs-webapp-test::default' do
       cwd: '/opt/test_b'
     )
   end
+
+  it 'removes temporary files from npm' do
+    expect(chef_run).to run_execute('Clear temp files')
+  end
+
+  it 'installs test_a as a pm2 application' do
+    expect(chef_run).to deploy_pm2_application('test_a').with(
+      script: 'run.js',
+      user: 'test_a',
+      cwd: '/opt/custom/source',
+      node_args: %w(--harmony --no-deprecation)
+    )
+  end
 end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -1,0 +1,22 @@
+require 'chefspec'
+require 'spec_helper'
+
+describe 'nodejs-webapp-test::default' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      step_into: ['nodejs-webapp']
+    ).converge(described_recipe)
+  end
+
+  it 'runs app test_run' do
+    expect(chef_run).to run_nodejs_webapp('test_run')
+  end
+
+  it 'should start or restart app script run.js with pm2' do
+    expect(chef_run).to start_pm2_application('test_run').with(
+      script: 'run.js',
+      user: 'test_run',
+      node_args: %w(--harmony --no-deprecation)
+    )
+  end
+end

--- a/test/cookbooks/nodejs-webapp-test/recipes/default.rb
+++ b/test/cookbooks/nodejs-webapp-test/recipes/default.rb
@@ -44,6 +44,8 @@ nodejs_webapp 'test_a' do
   branch 'custom'
 
   node_args ['--harmony', '--no-deprecation']
+
+  action :install
 end
 
 nodejs_webapp 'test_b' do
@@ -51,4 +53,18 @@ nodejs_webapp 'test_b' do
   repository 'https://github.com/osuosl/nodejs-test-apps.git'
   install_deps false
   branch 'master'
+end
+
+nodejs_webapp 'test_run' do
+  path '/opt/test_run'
+  user 'test_run'
+  group 'test_run'
+
+  script 'run.js'
+  repository 'https://github.com/osuosl/nodejs-test-apps.git'
+  branch 'custom'
+
+  node_args ['--harmony', '--no-deprecation']
+
+  action :run
 end


### PR DESCRIPTION
While working on cleaning up this and the timesync cookbook, I realized that we're ultimately calling "pm2 start" twice, once in that cookbook and once in this. So my first step in resolving this is to split this cookbook into an "install" action, which creates the user/group, installs/upgrades npm, pulls the project from git, and creates the PM2 config; and a "run" action, which starts the PM2 application and saves the deploy script.
